### PR TITLE
SW-201 Fix CoreData Persistence

### DIFF
--- a/SmartWeights/SmartWeights/DBAccess/CoreDataManager.swift
+++ b/SmartWeights/SmartWeights/DBAccess/CoreDataManager.swift
@@ -9,13 +9,10 @@ import Foundation
 import CoreData
 
 class CoreDataManager: ObservableObject {
-    
-    let persistentContainer: NSPersistentCloudKitContainer
+    // Use the shared managed object model defined in PersistenceController
+    let persistentContainer: NSPersistentCloudKitContainer = PersistenceController.shared.container
     
     init() {
-        // Use the shared managed object model defined in PersistenceController
-        persistentContainer = NSPersistentCloudKitContainer(name: "SmartWeights", managedObjectModel: PersistenceController.sharedManagedObjectModel)
-            
             let description = NSPersistentStoreDescription()
             description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
             description.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)

--- a/SmartWeights/SmartWeights/Persistence.swift
+++ b/SmartWeights/SmartWeights/Persistence.swift
@@ -49,11 +49,6 @@ struct PersistenceController {
     init(inMemory: Bool = false) {
             container = NSPersistentCloudKitContainer(name: "SmartWeights", managedObjectModel: PersistenceController.sharedManagedObjectModel)
         
-        // Configures the persistent store for in-memory use if specified. This is useful for unit tests or preview functionality.
-        if inMemory {
-            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
-        }
-        
         // Loads the persistent stores and handles any errors.
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
@@ -74,5 +69,19 @@ struct PersistenceController {
         
         // Ensures that the viewContext automatically merges changes saved in any context that is a child of the main context.
         container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+}
+
+extension PersistenceController {
+    func saveContext() {
+        let context = container.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
     }
 }

--- a/SmartWeights/SmartWeights/SmartWeightsApp.swift
+++ b/SmartWeights/SmartWeights/SmartWeightsApp.swift
@@ -6,9 +6,40 @@
 //
 
 import SwiftUI
+import CoreData
+
+// AppDelegate class
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        return true
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        saveContext()
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        saveContext()
+    }
+
+    func saveContext() {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+
+    lazy var persistentContainer: NSPersistentContainer = PersistenceController.shared.container
+}
 
 @main
 struct SmartWeightsApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
Removed unnecessary inMemory lines from Persistence.swift, also changed/removed an initialization to make sure the NSPersistentObject is correctly called and the same one is used throughout the app

Fixed the issue of the CoreData entities/attributes not saving correctly when closing and reopening app.

The user should now be able to see the past workouts even after closing out of the app.